### PR TITLE
Rounded Rect additional initializator (v1.0.10)

### DIFF
--- a/CrispyCalendar.podspec
+++ b/CrispyCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 	spec.name         = 'CrispyCalendar'
-	spec.version      = '1.0.9'
+	spec.version      = '1.0.10'
 	spec.license      = { :type => 'MIT' }
 	spec.homepage     = "https://github.com/CleverPumpkin/crispycalendar"
 	spec.authors      = { 'Cleverpumpkin, Ltd.' => 'cleverpumpkin.ru' }

--- a/CrispyCalendar/CustomUI/RoundRectCrispyCalendarVC/RoundRectCrispyCalendarVC.swift
+++ b/CrispyCalendar/CustomUI/RoundRectCrispyCalendarVC/RoundRectCrispyCalendarVC.swift
@@ -66,6 +66,22 @@ public class RoundRectCrispyCalendarVC: CPCCalendarViewController {
 		self.weekView = weekView
 	}
 	
+	public init(
+		renderModel: RoundRectRenderModel,
+		weekView: CPCWeekView,
+		calendar: Calendar
+	) {
+		self.renderModel = renderModel
+		self.calendar = calendar
+		
+		super.init(nibName: nil, bundle: nil)
+		
+		self.weekView = weekView
+		
+		calendarView.showsVerticalScrollIndicator = false
+		calendarView.showsHorizontalScrollIndicator = false
+	}
+	
 	required init?(coder aDecoder: NSCoder) {
 		self.renderModel = RoundRectRenderModel(
 			roundRectTitleModel: RoundRectTitleModel(

--- a/CrispyCalendar/View/CPCCalendarViewController.swift
+++ b/CrispyCalendar/View/CPCCalendarViewController.swift
@@ -210,7 +210,11 @@ open class CPCCalendarViewController: UIViewController {
 	
 	// MARK: - Initialization
 	
-	public init(dateRange: ClosedRange<Date>, calendar: Calendar = .current) {
+	public init(
+		dateRange: ClosedRange<Date>,
+		calendar: Calendar = .current,
+		startingDay: Date = Date()
+	) {
 		
 		let maximumDay = CPCDay(containing: dateRange.upperBound, calendar: calendar)
 		let minimumDay = CPCDay(containing: dateRange.lowerBound, calendar: calendar)
@@ -228,7 +232,7 @@ open class CPCCalendarViewController: UIViewController {
 		}
 		
 		self.numberOfMonthsToDisplay = numberOfMonthsToDisplay
-		self.startingDay = CPCDay(containing: dateRange.lowerBound, calendar: .current)
+		self.startingDay = CPCDay(containing: startingDay, calendar: .current)
 		
 		super.init(nibName: nil, bundle: nil)
 		

--- a/CrispyCalendar/View/CPCCalendarViewController.swift
+++ b/CrispyCalendar/View/CPCCalendarViewController.swift
@@ -212,8 +212,7 @@ open class CPCCalendarViewController: UIViewController {
 	
 	public init(
 		dateRange: ClosedRange<Date>,
-		calendar: Calendar = .current,
-		startingDay: Date = Date()
+		calendar: Calendar = .current
 	) {
 		
 		let maximumDay = CPCDay(containing: dateRange.upperBound, calendar: calendar)
@@ -232,7 +231,8 @@ open class CPCCalendarViewController: UIViewController {
 		}
 		
 		self.numberOfMonthsToDisplay = numberOfMonthsToDisplay
-		self.startingDay = CPCDay(containing: startingDay, calendar: .current)
+		
+		self.startingDay = CPCDay(containing: dateRange.lowerBound, calendar: .current)
 		
 		super.init(nibName: nil, bundle: nil)
 		


### PR DESCRIPTION
C добавлением параметра startingDay в инит ничего хорошего не вышло, поэтому я просто добавил дополнительный инициализатор в RoundedRectCalendarVC. Он будет инитить календарь с бесконечным скролом, на сегодняшней дате и без скролл индикаторов.